### PR TITLE
Workspace Support

### DIFF
--- a/canonicalRequest/canonicalRequest.go
+++ b/canonicalRequest/canonicalRequest.go
@@ -5,7 +5,7 @@ import (
   "net/url"
   "strings"
   "fmt"
-  "../utilities"
+  "github.com/udryan10/hmacurl/utilities"
   )
 
 

--- a/hmacurl.go
+++ b/hmacurl.go
@@ -1,11 +1,11 @@
 package main
 
 import (
-	"./canonicalRequest"
-	"./signString"
-	"./signature"
-	"./utilities"
-	"./validation"
+	"github.com/udryan10/hmacurl/canonicalRequest"
+	"github.com/udryan10/hmacurl/signString"
+	"github.com/udryan10/hmacurl/signature"
+	"github.com/udryan10/hmacurl/utilities"
+	"github.com/udryan10/hmacurl/validation"
 	"bytes"
 	"fmt"
 	"github.com/jessevdk/go-flags"


### PR DESCRIPTION
Removed all relative import paths so that this can be used in a Go
workspace. See http://golang.org/cmd/go/#hdr-Relative_import_paths.
