### PR TITLE
Explicit credential scope support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,40 @@ Usage:
 
 Application Options:
   -X, --request=GET|POST                           the http method to use (GET)
-  -d, --data='my string body'                      for POST requests, the data to be uploaded as the body. Used if -f is not provided.
-  -f, --file=./file.txt                            for POST requests, the file to be uploaded as the body. Used if -d is not provided
-  -H, --header='Content-Type: application/json'    Extra header(s) to include in the request when sending HTTP to a server. You may specify any number of extra headers.
-      --curl-only                                  If specified, will only print out a curl command - not actually run a request (false)
-  -a, --access-key=                                The access Key to use in HMAC signing. Can also be specified as an environment variable(export HMACURL_ACCESS_KEY='fasdf')
-  -s, --secret-key=                                The secret Key to use in HMAC signing. Can also be specified as an environment variable(export HMACURL_SECRET_KEY='fasdf')
-      --debug                                      Whether to output debug information (false)
+  -d, --data='my string body'                      for POST requests, the data
+                                                   to be uploaded as the body.
+                                                   Used if -f is not provided.
+  -f, --file=./file.txt                            for POST requests, the file
+                                                   to be uploaded as the body.
+                                                   Used if -d is not provided
+  -H, --header='Content-Type: application/json'    Extra header(s) to include
+                                                   in the request when sending
+                                                   HTTP to a server. You may
+                                                   specify any number of extra
+                                                   headers.
+      --curl-only                                  If specified, will only
+                                                   print out a curl command -
+                                                   not actually run a request
+                                                   (false)
+  -a, --access-key=                                The access Key to use in
+                                                   HMAC signing. Can also be
+                                                   specified as an environment
+                                                   variable(export
+                                                   HMACURL_ACCESS_KEY='fasdf')
+  -s, --secret-key=                                The secret Key to use in
+                                                   HMAC signing. Can also be
+                                                   specified as an environment
+                                                   variable(export
+                                                   HMACURL_SECRET_KEY='fasdf')
+  -c, --credential-scope=                          The credential scope (aka
+                                                   Service Name) for the
+                                                   request. Defaults to short
+                                                   host name.
+      --skip-host                                  Do not sign the Host header
+                                                   (useful for non-standard
+                                                   HMAC implementations) (false)
+      --debug                                      Whether to output debug
+                                                   information (false)
 
 Help Options:
   -h, --help                                       Show this help message


### PR DESCRIPTION
To allow hmacurl to hit AWS API Gateway endpoints published behind a custom domain, it's necessary to be able to specify the credential scope explicitly, rather than simply using the host name. For API Gateway, the credential scope is execute-api. 
