### PR TITLE
Added support for alternate regions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ Application Options:
                                                    Service Name) for the
                                                    request. Defaults to short
                                                    host name.
+  -r, --region=                                    The region string to use in
+                                                   the credential scope.
+                                                   Defaults to us-east-1.
       --skip-host                                  Do not sign the Host header
                                                    (useful for non-standard
                                                    HMAC implementations) (false)

--- a/README.md
+++ b/README.md
@@ -48,10 +48,12 @@ Application Options:
                                                    host name.
   -r, --region=                                    The region string to use in
                                                    the credential scope.
-                                                   Defaults to us-east-1.
+                                                   (default: us-east-1)
       --skip-host                                  Do not sign the Host header
                                                    (useful for non-standard
                                                    HMAC implementations) (false)
+  -p, --proxy=                                     Proxy server to use if not
+                                                   set via environment variable.
       --debug                                      Whether to output debug
                                                    information (false)
 

--- a/canonicalRequest/canonicalRequest.go
+++ b/canonicalRequest/canonicalRequest.go
@@ -1,41 +1,42 @@
 package canonicalRequest
 
 import (
-  "sort"
-  "net/url"
-  "strings"
-  "fmt"
-  "github.com/udryan10/hmacurl/utilities"
-  )
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
 
+	"github.com/udryan10/hmacurl/utilities"
+)
 
 func FormatCanonicalString(method string, url *url.URL, headerMap map[string]string, payload string) string {
-  // format string in HTTPRequestMethod, CanonicalURI, CanonicalQueryString, CanonicalHeaders, SignedHeaders, HexEncode(Hash(RequestPayload))
-  canonicalString := fmt.Sprintf("%s\n%s\n%s\n%s\n%s\n%s", method, url.Path, url.RawQuery, formatHeaders(headerMap), FormatSignedHeaders(headerMap), utilities.DataToSha256Encoded([]byte(payload)))
-  return canonicalString
+	// format string in HTTPRequestMethod, CanonicalURI, CanonicalQueryString, CanonicalHeaders, SignedHeaders, HexEncode(Hash(RequestPayload))
+	canonicalQueryStrings := strings.Replace(url.Query().Encode(), "+", "%20", -1)
+	canonicalString := fmt.Sprintf("%s\n%s\n%s\n%s\n%s\n%s", method, url.Path, canonicalQueryStrings, formatHeaders(headerMap), FormatSignedHeaders(headerMap), utilities.DataToSha256Encoded([]byte(payload)))
+	return canonicalString
 }
 
 func formatHeaders(headers map[string]string) string {
-  var sorted[]string
+	var sorted []string
 
-  for k := range headers {
-    sorted = append(sorted,k)
-  }
-  sort.Strings(sorted)
+	for k := range headers {
+		sorted = append(sorted, k)
+	}
+	sort.Strings(sorted)
 
-  headerString := ""
-  for _,v := range sorted {
-    headerString += fmt.Sprintf("%s:%s\n", strings.TrimSpace(strings.ToLower(v)), strings.TrimSpace(headers[v]))
-  }
-  return headerString
+	headerString := ""
+	for _, v := range sorted {
+		headerString += fmt.Sprintf("%s:%s\n", strings.TrimSpace(strings.ToLower(v)), strings.TrimSpace(headers[v]))
+	}
+	return headerString
 }
 
 func FormatSignedHeaders(headers map[string]string) string {
-  var sorted[]string
+	var sorted []string
 
-  for k := range headers {
-    sorted = append(sorted,strings.ToLower(k))
-  }
-  sort.Strings(sorted)
-  return strings.Join(sorted,";")
+	for k := range headers {
+		sorted = append(sorted, strings.ToLower(k))
+	}
+	sort.Strings(sorted)
+	return strings.Join(sorted, ";")
 }

--- a/hmacurl.go
+++ b/hmacurl.go
@@ -42,7 +42,7 @@ var opts struct {
 
 	CredentialScope string `short:"c" long:"credential-scope" default:"" description:"The credential scope (aka Service Name) for the request. Defaults to short host name."`
 
-	Region string `short:"r" long:"region" default:"us-east-1" description:"The region to use in the credential scope. Default to us-east-1."`
+	Region string `short:"r" long:"region" default:"us-east-1" description:"The region to use in the credential scope."`
 
 	SkipHost bool `short:"" long:"skip-host" default:"false" description:"Do not sign the Host header (useful for non-standard HMAC implementations)"`
 

--- a/signString/signString.go
+++ b/signString/signString.go
@@ -1,12 +1,12 @@
 package signString
 
 import (
-  "fmt"
-  "time"
-  )
+	"fmt"
+	"time"
+)
 
-func StringToSign(requestTime time.Time, canonicalRequest string, service string) string {
-  credentialScope := fmt.Sprintf("%s/%s/%s/%s",requestTime.Format("20060102"), "us-east-1", service, "aws4_request")
-  stringToSign := fmt.Sprintf("%s\n%s\n%s\n%s", "AWS4-HMAC-SHA256", requestTime.Format("20060102T150405Z"), credentialScope, canonicalRequest)
-  return stringToSign
+func StringToSign(requestTime time.Time, canonicalRequest, region, service string) string {
+	credentialScope := fmt.Sprintf("%s/%s/%s/%s", requestTime.Format("20060102"), region, service, "aws4_request")
+	stringToSign := fmt.Sprintf("%s\n%s\n%s\n%s", "AWS4-HMAC-SHA256", requestTime.Format("20060102T150405Z"), credentialScope, canonicalRequest)
+	return stringToSign
 }

--- a/signature/signature.go
+++ b/signature/signature.go
@@ -1,29 +1,29 @@
 package signature
 
 import (
-  "crypto/hmac"
-  "crypto/sha256"
-  "time"
-  "encoding/hex"
-  )
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"time"
+)
 
 func ComputeHmac256(secret []byte, message string) []byte {
-  key := []byte(secret)
-  h := hmac.New(sha256.New, key)
-  h.Write([]byte(message))
-  return h.Sum(nil)
+	key := []byte(secret)
+	h := hmac.New(sha256.New, key)
+	h.Write([]byte(message))
+	return h.Sum(nil)
 }
 
-func calculateSigningKey(requestTime time.Time, service string, secret string) []byte {
-  kSecret := secret
-  //kDate := ComputeHmac256("AWS4" + kSecret, requestTime.Format("20060102"))
-  kDate := ComputeHmac256([]byte("AWS4" + kSecret), requestTime.Format("20060102"))
-  kRegion := ComputeHmac256(kDate, "us-east-1")
-  kService := ComputeHmac256(kRegion,service)
-  kSigning :=  ComputeHmac256(kService, "aws4_request")
-  return kSigning
+func calculateSigningKey(requestTime time.Time, region, service, secret string) []byte {
+	kSecret := secret
+	//kDate := ComputeHmac256("AWS4" + kSecret, requestTime.Format("20060102"))
+	kDate := ComputeHmac256([]byte("AWS4"+kSecret), requestTime.Format("20060102"))
+	kRegion := ComputeHmac256(kDate, region)
+	kService := ComputeHmac256(kRegion, service)
+	kSigning := ComputeHmac256(kService, "aws4_request")
+	return kSigning
 }
 
-func CalculateSignature(requestTime time.Time, message string, service string, secret string) string {
-  return hex.EncodeToString(ComputeHmac256(calculateSigningKey(requestTime, service, secret),message))
+func CalculateSignature(requestTime time.Time, message, region, service, secret string) string {
+	return hex.EncodeToString(ComputeHmac256(calculateSigningKey(requestTime, region, service, secret), message))
 }

--- a/utilities/utilities.go
+++ b/utilities/utilities.go
@@ -1,16 +1,16 @@
 package utilities
 
 import (
-  "crypto/sha256"
-  "encoding/hex"
-  "fmt"
-  )
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+)
 
-func DataToSha256Encoded(data []byte) string{
-  sha := sha256.Sum256(data)
-  return hex.EncodeToString(sha[:])
+func DataToSha256Encoded(data []byte) string {
+	sha := sha256.Sum256(data)
+	return hex.EncodeToString(sha[:])
 }
 
-func GenerateSignedHeader(accessKey string, signature string, host string, date string, signedHeaders string) string{
-  return fmt.Sprintf("%s Credential=%s/%s/%s/%s/%s, SignedHeaders=%s, Signature=%s", "AWS4-HMAC-SHA256", accessKey, date, "us-east-1", host, "aws4_request", signedHeaders, signature )
+func GenerateSignedHeader(accessKey, signature, region, service, date, signedHeaders string) string {
+	return fmt.Sprintf("%s Credential=%s/%s/%s/%s/%s, SignedHeaders=%s, Signature=%s", "AWS4-HMAC-SHA256", accessKey, date, region, service, "aws4_request", signedHeaders, signature)
 }


### PR DESCRIPTION
Removed the hard-coded us-east-1 region in the credential scope. This allows hmacurl to be used against region-specific endpoints in other AWS regions. 

Fixed the query string encoding so it is consistent with the AWS SDK's method of encoding. This includes replacement of '+' with '%20' to encode spaces.

Also added single quotes around the --curl-only output so that query strings with & in them are runnable via direct cut and paste. 
